### PR TITLE
Add diff color display to edit confirmation modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-gemini-helper",
-  "version": "1.1.3",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-gemini-helper",
-      "version": "1.1.3",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.32.0",

--- a/src/ui/components/Chat.tsx
+++ b/src/ui/components/Chat.tsx
@@ -892,7 +892,8 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 										plugin.app,
 										pending.originalPath,
 										pending.newContent,
-										"overwrite"
+										"overwrite",
+										pending.originalContent
 									);
 
 									if (confirmed) {


### PR DESCRIPTION
The single file edit confirmation modal now shows colored diff view
with green for added lines and red for removed lines, matching the
bulk edit modal behavior. Pass originalContent to promptForConfirmation
so the modal can compute and display the diff.