### PR TITLE
Add OAuth Authorization Code Flow support for MCP servers

### DIFF
--- a/src/core/oauth.ts
+++ b/src/core/oauth.ts
@@ -1,0 +1,490 @@
+// OAuth 2.0 Authorization Code Flow with PKCE for MCP servers
+// Uses Obsidian's registerObsidianProtocolHandler for callback handling
+// Supports MCP OAuth auto-discovery via RFC 9728 (Protected Resource Metadata)
+
+import { requestUrl } from "obsidian";
+
+// OAuth configuration for an MCP server
+export interface OAuthConfig {
+  clientId: string;
+  authorizationUrl: string;      // Authorization endpoint
+  tokenUrl: string;              // Token endpoint
+  scopes: string[];              // Required scopes
+  clientSecret?: string;         // Optional client secret (not recommended for public clients)
+}
+
+// OAuth tokens stored for an MCP server
+export interface OAuthTokens {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;            // Unix timestamp in milliseconds
+  tokenType?: string;            // Usually "Bearer"
+}
+
+// Protected Resource Metadata (RFC 9728)
+interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers?: string[];
+  scopes_supported?: string[];
+}
+
+// OAuth Authorization Server Metadata (RFC 8414)
+interface AuthorizationServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  scopes_supported?: string[];
+  response_types_supported?: string[];
+  code_challenge_methods_supported?: string[];
+  // MCP-specific: client registration
+  registration_endpoint?: string;
+}
+
+// Result of OAuth discovery
+export interface OAuthDiscoveryResult {
+  config: OAuthConfig;
+  serverMetadata: AuthorizationServerMetadata;
+  resourceMetadata: ProtectedResourceMetadata;
+}
+
+// Pending OAuth state for tracking authorization flow
+interface PendingOAuthState {
+  serverName: string;
+  config: OAuthConfig;           // OAuth config for token exchange
+  codeVerifier: string;          // PKCE code verifier
+  resolve: (tokens: OAuthTokens) => void;
+  reject: (error: Error) => void;
+  timeoutId: ReturnType<typeof setTimeout>;
+}
+
+// Protocol action name for OAuth callback
+export const OAUTH_PROTOCOL_ACTION = "gemini-helper-oauth";
+
+// Callback URL format: obsidian://gemini-helper-oauth?code=xxx&state=yyy
+export function getOAuthRedirectUri(): string {
+  return `obsidian://${OAUTH_PROTOCOL_ACTION}`;
+}
+
+// Store pending OAuth states by state parameter
+const pendingStates = new Map<string, PendingOAuthState>();
+
+// OAuth timeout (5 minutes)
+const OAUTH_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Generate a random string for state and PKCE
+ */
+function generateRandomString(length: number): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+  const array = new Uint8Array(length);
+  crypto.getRandomValues(array);
+  return Array.from(array, (byte) => chars[byte % chars.length]).join("");
+}
+
+/**
+ * Generate PKCE code challenge from verifier (SHA256 + base64url)
+ */
+async function generateCodeChallenge(verifier: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+
+  // Convert to base64url
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Build authorization URL with PKCE
+ */
+export async function buildAuthorizationUrl(
+  config: OAuthConfig,
+  state: string,
+  codeVerifier: string
+): Promise<string> {
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    response_type: "code",
+    redirect_uri: getOAuthRedirectUri(),
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+  });
+
+  // Only add scope if scopes are provided (empty scope can cause invalid_scope error)
+  if (config.scopes.length > 0) {
+    params.set("scope", config.scopes.join(" "));
+  }
+
+  return `${config.authorizationUrl}?${params.toString()}`;
+}
+
+/**
+ * Exchange authorization code for tokens
+ */
+export async function exchangeCodeForTokens(
+  config: OAuthConfig,
+  code: string,
+  codeVerifier: string
+): Promise<OAuthTokens> {
+  const body: Record<string, string> = {
+    grant_type: "authorization_code",
+    client_id: config.clientId,
+    code,
+    redirect_uri: getOAuthRedirectUri(),
+    code_verifier: codeVerifier,
+  };
+
+  if (config.clientSecret) {
+    body.client_secret = config.clientSecret;
+  }
+
+  const response = await requestUrl({
+    url: config.tokenUrl,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams(body).toString(),
+  });
+
+  const data = response.json;
+
+  if (data.error) {
+    throw new Error(`OAuth token error: ${data.error} - ${data.error_description || ""}`);
+  }
+
+  const tokens: OAuthTokens = {
+    accessToken: data.access_token,
+    tokenType: data.token_type || "Bearer",
+  };
+
+  if (data.refresh_token) {
+    tokens.refreshToken = data.refresh_token;
+  }
+
+  if (data.expires_in) {
+    tokens.expiresAt = Date.now() + data.expires_in * 1000;
+  }
+
+  return tokens;
+}
+
+/**
+ * Refresh access token using refresh token
+ */
+export async function refreshAccessToken(
+  config: OAuthConfig,
+  refreshToken: string
+): Promise<OAuthTokens> {
+  const body: Record<string, string> = {
+    grant_type: "refresh_token",
+    client_id: config.clientId,
+    refresh_token: refreshToken,
+  };
+
+  if (config.clientSecret) {
+    body.client_secret = config.clientSecret;
+  }
+
+  const response = await requestUrl({
+    url: config.tokenUrl,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams(body).toString(),
+  });
+
+  const data = response.json;
+
+  if (data.error) {
+    throw new Error(`OAuth refresh error: ${data.error} - ${data.error_description || ""}`);
+  }
+
+  const tokens: OAuthTokens = {
+    accessToken: data.access_token,
+    tokenType: data.token_type || "Bearer",
+  };
+
+  // Some providers return a new refresh token
+  if (data.refresh_token) {
+    tokens.refreshToken = data.refresh_token;
+  } else {
+    // Keep the existing refresh token
+    tokens.refreshToken = refreshToken;
+  }
+
+  if (data.expires_in) {
+    tokens.expiresAt = Date.now() + data.expires_in * 1000;
+  }
+
+  return tokens;
+}
+
+/**
+ * Check if tokens are expired or about to expire (within 5 minutes)
+ */
+export function isTokenExpired(tokens: OAuthTokens): boolean {
+  if (!tokens.expiresAt) {
+    return false; // No expiration info, assume valid
+  }
+  // Consider expired if within 5 minutes of expiration
+  return Date.now() >= tokens.expiresAt - 5 * 60 * 1000;
+}
+
+/**
+ * Start OAuth authorization flow
+ * Returns a promise that resolves when the callback is received
+ */
+export function startAuthorizationFlow(
+  serverName: string,
+  config: OAuthConfig
+): Promise<OAuthTokens> {
+  return new Promise((resolve, reject) => {
+    const state = generateRandomString(32);
+    const codeVerifier = generateRandomString(64);
+
+    // Set timeout for OAuth flow
+    const timeoutId = setTimeout(() => {
+      pendingStates.delete(state);
+      reject(new Error("OAuth authorization timed out"));
+    }, OAUTH_TIMEOUT_MS);
+
+    // Store pending state
+    pendingStates.set(state, {
+      serverName,
+      config,
+      codeVerifier,
+      resolve,
+      reject,
+      timeoutId,
+    });
+
+    // Build and open authorization URL
+    buildAuthorizationUrl(config, state, codeVerifier)
+      .then((url) => {
+        // Open in default browser
+        window.open(url, "_blank");
+      })
+      .catch((error) => {
+        pendingStates.delete(state);
+        clearTimeout(timeoutId);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+  });
+}
+
+/**
+ * Handle OAuth callback from protocol handler
+ * Called by the plugin when receiving obsidian://gemini-helper-oauth
+ * Returns tokens and config so both can be persisted
+ */
+export async function handleOAuthCallback(
+  params: Record<string, string>
+): Promise<{ serverName: string; tokens: OAuthTokens; config: OAuthConfig } | null> {
+  const { code, state, error, error_description } = params;
+
+  // Check for OAuth error response
+  if (error) {
+    const pendingState = state ? pendingStates.get(state) : null;
+    if (pendingState) {
+      clearTimeout(pendingState.timeoutId);
+      pendingStates.delete(state);
+      pendingState.reject(new Error(`OAuth error: ${error} - ${error_description || ""}`));
+    }
+    return null;
+  }
+
+  if (!state || !code) {
+    console.error("OAuth callback missing state or code");
+    return null;
+  }
+
+  const pendingState = pendingStates.get(state);
+  if (!pendingState) {
+    console.error("OAuth callback with unknown state:", state);
+    return null;
+  }
+
+  // Clear timeout and remove pending state
+  clearTimeout(pendingState.timeoutId);
+  pendingStates.delete(state);
+
+  try {
+    // Exchange code for tokens using stored config
+    const tokens = await exchangeCodeForTokens(pendingState.config, code, pendingState.codeVerifier);
+    pendingState.resolve(tokens);
+    // Return config along with tokens so it can be persisted for future token refresh
+    return { serverName: pendingState.serverName, tokens, config: pendingState.config };
+  } catch (err) {
+    pendingState.reject(err instanceof Error ? err : new Error(String(err)));
+    return null;
+  }
+}
+
+/**
+ * Cancel pending OAuth flow for a server
+ */
+export function cancelPendingOAuth(serverName: string): void {
+  for (const [state, pending] of pendingStates.entries()) {
+    if (pending.serverName === serverName) {
+      clearTimeout(pending.timeoutId);
+      pendingStates.delete(state);
+      pending.reject(new Error("OAuth authorization cancelled"));
+    }
+  }
+}
+
+/**
+ * Check if there's a pending OAuth flow for a server
+ */
+export function hasPendingOAuth(serverName: string): boolean {
+  for (const pending of pendingStates.values()) {
+    if (pending.serverName === serverName) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Get number of pending OAuth flows (for debugging)
+ */
+export function getPendingOAuthCount(): number {
+  return pendingStates.size;
+}
+
+/**
+ * Discover OAuth configuration from MCP server using RFC 9728
+ * First tries to get resource_metadata URL from WWW-Authenticate header,
+ * then falls back to well-known URL at origin
+ */
+export async function discoverOAuthFromServer(serverUrl: string): Promise<OAuthDiscoveryResult | null> {
+  const baseUrl = new URL(serverUrl);
+  const origin = baseUrl.origin;
+
+  // Step 1: Try to access the server to check for WWW-Authenticate header with resource_metadata
+  let resourceMetadataUrl: string | null = null;
+  try {
+    // Make a request to see if we get a 401 with WWW-Authenticate
+    // Use throw: false to get the response even on 4xx status
+    const response = await requestUrl({
+      url: serverUrl,
+      method: "POST",
+      headers: {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 0 }),
+      throw: false,
+    });
+
+    // Check if we got a 401 with WWW-Authenticate header (RFC 9728)
+    if (response.status === 401) {
+      const wwwAuth = response.headers["www-authenticate"];
+      if (wwwAuth) {
+        resourceMetadataUrl = parseWwwAuthenticateHeader(wwwAuth);
+      }
+    }
+    // For 2xx or other error statuses, fall through to well-known check
+  } catch {
+    // Network error or other issue - fall through to well-known check
+  }
+
+  // Step 2: Use resource_metadata from header if available, otherwise use well-known URL
+  if (resourceMetadataUrl) {
+    return discoverOAuthFromMetadataUrl(resourceMetadataUrl);
+  }
+
+  // Fall back to well-known URL at origin
+  const wellKnownUrl = `${origin}/.well-known/oauth-protected-resource`;
+  return discoverOAuthFromMetadataUrl(wellKnownUrl);
+}
+
+/**
+ * Try to discover OAuth from a 401 response's WWW-Authenticate header
+ * Returns the resource_metadata URL if present
+ */
+export function parseWwwAuthenticateHeader(header: string): string | null {
+  // Parse WWW-Authenticate: Bearer resource_metadata="https://..."
+  const match = header.match(/resource_metadata="([^"]+)"/);
+  if (match) {
+    return match[1];
+  }
+  return null;
+}
+
+/**
+ * Fetch OAuth config from a resource_metadata URL
+ */
+export async function discoverOAuthFromMetadataUrl(resourceMetadataUrl: string): Promise<OAuthDiscoveryResult | null> {
+  // Step 1: Fetch Protected Resource Metadata
+  let resourceMetadata: ProtectedResourceMetadata;
+  try {
+    const response = await requestUrl({
+      url: resourceMetadataUrl,
+      method: "GET",
+      headers: {
+        "Accept": "application/json",
+      },
+    });
+    resourceMetadata = response.json as ProtectedResourceMetadata;
+  } catch {
+    return null;
+  }
+
+  // Step 2: Get authorization server URL
+  const authServers = resourceMetadata.authorization_servers;
+  if (!authServers || authServers.length === 0) {
+    return null;
+  }
+
+  const authServerUrl = authServers[0];
+
+  // Step 3: Fetch Authorization Server Metadata
+  let serverMetadata: AuthorizationServerMetadata;
+  try {
+    const authServerOrigin = new URL(authServerUrl).origin;
+    const metadataUrl = `${authServerOrigin}/.well-known/oauth-authorization-server`;
+    const response = await requestUrl({
+      url: metadataUrl,
+      method: "GET",
+      headers: {
+        "Accept": "application/json",
+      },
+    });
+    serverMetadata = response.json as AuthorizationServerMetadata;
+  } catch {
+    try {
+      const authServerOrigin = new URL(authServerUrl).origin;
+      const oidcUrl = `${authServerOrigin}/.well-known/openid-configuration`;
+      const response = await requestUrl({
+        url: oidcUrl,
+        method: "GET",
+        headers: {
+          "Accept": "application/json",
+        },
+      });
+      serverMetadata = response.json as AuthorizationServerMetadata;
+    } catch {
+      return null;
+    }
+  }
+
+  // Step 4: Build OAuth config
+  const config: OAuthConfig = {
+    clientId: "obsidian-gemini-helper",
+    authorizationUrl: serverMetadata.authorization_endpoint,
+    tokenUrl: serverMetadata.token_endpoint,
+    scopes: resourceMetadata.scopes_supported || serverMetadata.scopes_supported || [],
+  };
+
+  return {
+    config,
+    serverMetadata,
+    resourceMetadata,
+  };
+}

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -750,4 +750,42 @@ export const de: Record<string, string> = {
   "mcpApp.collapse": "Minimieren",
   "mcpApp.error": "MCP App Fehler",
   "mcpApp.decodeError": "Binärinhalt konnte nicht dekodiert werden",
+
+  // MCP Server Settings
+  "settings.mcpServers": "MCP-Server",
+  "settings.mcpServers.desc": "Externe MCP-Server (Model Context Protocol) für zusätzliche Tools konfigurieren",
+  "settings.mcpServersIntro": "MCP-Server bieten zusätzliche Tools. Server hinzufügen, um deren Tools zu aktivieren.",
+  "settings.addMcpServer": "Server hinzufügen",
+  "settings.mcpServerName": "Servername",
+  "settings.mcpServerName.placeholder": "Mein MCP-Server",
+  "settings.mcpServerUrl": "Server-URL",
+  "settings.mcpServerUrl.placeholder": "https://example.com/mcp",
+  "settings.mcpServerHeaders": "Header (JSON)",
+  "settings.mcpServerHeaders.placeholder": "{\"Authorization\": \"Bearer xxx\"}",
+  "settings.mcpServerHeaders.desc": "Optionale Header für Authentifizierung (JSON-Format)",
+  "settings.editMcpServer": "MCP-Server bearbeiten",
+  "settings.createMcpServer": "MCP-Server hinzufügen",
+  "settings.mcpServerCreated": "MCP-Server \"{{name}}\" hinzugefügt",
+  "settings.mcpServerUpdated": "MCP-Server \"{{name}}\" aktualisiert",
+  "settings.mcpServerDeleted": "MCP-Server \"{{name}}\" gelöscht",
+  "settings.mcpServerNameRequired": "Servername ist erforderlich",
+  "settings.mcpServerNameDuplicate": "Servername \"{{name}}\" existiert bereits",
+  "settings.mcpServerUrlRequired": "Server-URL ist erforderlich",
+  "settings.mcpServerInvalidHeaders": "Ungültiges JSON für Header",
+  "settings.testMcpConnection": "Verbinden",
+  "settings.mcpConnectionSuccess": "Verbindung erfolgreich! {{count}} Tool(s) verfügbar",
+  "settings.mcpConnectionFailed": "Verbindung fehlgeschlagen: {{error}}",
+  "settings.mcpNoServers": "Keine MCP-Server konfiguriert",
+  "settings.testConnectionRequired": "Verbindungstest vor dem Speichern erforderlich",
+  "settings.mcpToolHints": "Tools: {{tools}}",
+
+  // MCP OAuth settings
+  "settings.mcpOAuthEnabled.desc": "OAuth-Authentifizierung für diesen Server verwenden",
+  "settings.mcpOAuthAuthenticated": "Authentifiziert",
+  "settings.mcpOAuthAuthenticating": "Authentifizierung...",
+  "settings.oauthSuccess": "OAuth-Authentifizierung für \"{{name}}\" erfolgreich",
+  "settings.oauthFailed": "OAuth-Authentifizierung fehlgeschlagen: {{error}}",
+
+  // Input - MCP tool hint
+  "input.mcpToolHint": "({{count}} Tools: {{tools}})",
 };

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -669,14 +669,22 @@ export const en = {
   "settings.mcpServerUpdated": "Mcp server \"{{name}}\" updated",
   "settings.mcpServerDeleted": "Mcp server \"{{name}}\" deleted",
   "settings.mcpServerNameRequired": "Server name is required",
+  "settings.mcpServerNameDuplicate": "Server name \"{{name}}\" already exists",
   "settings.mcpServerUrlRequired": "Server URL is required",
   "settings.mcpServerInvalidHeaders": "Invalid JSON for headers",
-  "settings.testMcpConnection": "Test connection",
+  "settings.testMcpConnection": "Connect",
   "settings.mcpConnectionSuccess": "Connection successful! {{count}} tool(s) available",
   "settings.mcpConnectionFailed": "Connection failed: {{error}}",
   "settings.mcpNoServers": "No mcp servers configured",
   "settings.testConnectionRequired": "Test connection required before saving",
   "settings.mcpToolHints": "Tools: {{tools}}",
+
+  // MCP oauth settings
+  "settings.mcpOAuthEnabled.desc": "Server requires token-based authentication",
+  "settings.mcpOAuthAuthenticated": "Authenticated",
+  "settings.mcpOAuthAuthenticating": "Authenticating...",
+  "settings.oauthSuccess": "Successfully authenticated \"{{name}}\"",
+  "settings.oauthFailed": "Authentication failed: {{error}}",
 
   // Input - MCP tool hint
   "input.mcpToolHint": "({{count}} tools: {{tools}})",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -750,4 +750,42 @@ export const es: Record<string, string> = {
   "mcpApp.collapse": "Contraer",
   "mcpApp.error": "Error de MCP App",
   "mcpApp.decodeError": "No se pudo decodificar el contenido binario",
+
+  // MCP Server Settings
+  "settings.mcpServers": "Servidores MCP",
+  "settings.mcpServers.desc": "Configurar servidores MCP externos (Model Context Protocol) para herramientas adicionales",
+  "settings.mcpServersIntro": "Los servidores MCP proporcionan herramientas adicionales. Añade servidores para habilitar sus herramientas.",
+  "settings.addMcpServer": "Añadir servidor",
+  "settings.mcpServerName": "Nombre del servidor",
+  "settings.mcpServerName.placeholder": "Mi servidor MCP",
+  "settings.mcpServerUrl": "URL del servidor",
+  "settings.mcpServerUrl.placeholder": "https://example.com/mcp",
+  "settings.mcpServerHeaders": "Cabeceras (JSON)",
+  "settings.mcpServerHeaders.placeholder": "{\"Authorization\": \"Bearer xxx\"}",
+  "settings.mcpServerHeaders.desc": "Cabeceras opcionales para autenticación (formato JSON)",
+  "settings.editMcpServer": "Editar servidor MCP",
+  "settings.createMcpServer": "Añadir servidor MCP",
+  "settings.mcpServerCreated": "Servidor MCP \"{{name}}\" añadido",
+  "settings.mcpServerUpdated": "Servidor MCP \"{{name}}\" actualizado",
+  "settings.mcpServerDeleted": "Servidor MCP \"{{name}}\" eliminado",
+  "settings.mcpServerNameRequired": "El nombre del servidor es obligatorio",
+  "settings.mcpServerNameDuplicate": "El nombre del servidor \"{{name}}\" ya existe",
+  "settings.mcpServerUrlRequired": "La URL del servidor es obligatoria",
+  "settings.mcpServerInvalidHeaders": "JSON no válido para cabeceras",
+  "settings.testMcpConnection": "Conectar",
+  "settings.mcpConnectionSuccess": "¡Conexión exitosa! {{count}} herramienta(s) disponible(s)",
+  "settings.mcpConnectionFailed": "Conexión fallida: {{error}}",
+  "settings.mcpNoServers": "No hay servidores MCP configurados",
+  "settings.testConnectionRequired": "Se requiere probar la conexión antes de guardar",
+  "settings.mcpToolHints": "Herramientas: {{tools}}",
+
+  // MCP OAuth settings
+  "settings.mcpOAuthEnabled.desc": "Usar autenticación OAuth para este servidor",
+  "settings.mcpOAuthAuthenticated": "Autenticado",
+  "settings.mcpOAuthAuthenticating": "Autenticando...",
+  "settings.oauthSuccess": "Autenticación OAuth exitosa para \"{{name}}\"",
+  "settings.oauthFailed": "Autenticación OAuth fallida: {{error}}",
+
+  // Input - MCP tool hint
+  "input.mcpToolHint": "({{count}} herramientas: {{tools}})",
 };

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -750,4 +750,42 @@ export const fr: Record<string, string> = {
   "mcpApp.collapse": "Réduire",
   "mcpApp.error": "Erreur MCP App",
   "mcpApp.decodeError": "Échec du décodage du contenu binaire",
+
+  // MCP Server Settings
+  "settings.mcpServers": "Serveurs MCP",
+  "settings.mcpServers.desc": "Configurer des serveurs MCP externes (Model Context Protocol) pour des outils supplémentaires",
+  "settings.mcpServersIntro": "Les serveurs MCP fournissent des outils supplémentaires. Ajoutez des serveurs pour activer leurs outils.",
+  "settings.addMcpServer": "Ajouter un serveur",
+  "settings.mcpServerName": "Nom du serveur",
+  "settings.mcpServerName.placeholder": "Mon serveur MCP",
+  "settings.mcpServerUrl": "URL du serveur",
+  "settings.mcpServerUrl.placeholder": "https://example.com/mcp",
+  "settings.mcpServerHeaders": "En-têtes (JSON)",
+  "settings.mcpServerHeaders.placeholder": "{\"Authorization\": \"Bearer xxx\"}",
+  "settings.mcpServerHeaders.desc": "En-têtes optionnels pour l'authentification (format JSON)",
+  "settings.editMcpServer": "Modifier le serveur MCP",
+  "settings.createMcpServer": "Ajouter un serveur MCP",
+  "settings.mcpServerCreated": "Serveur MCP \"{{name}}\" ajouté",
+  "settings.mcpServerUpdated": "Serveur MCP \"{{name}}\" mis à jour",
+  "settings.mcpServerDeleted": "Serveur MCP \"{{name}}\" supprimé",
+  "settings.mcpServerNameRequired": "Le nom du serveur est requis",
+  "settings.mcpServerNameDuplicate": "Le nom du serveur \"{{name}}\" existe déjà",
+  "settings.mcpServerUrlRequired": "L'URL du serveur est requise",
+  "settings.mcpServerInvalidHeaders": "JSON invalide pour les en-têtes",
+  "settings.testMcpConnection": "Connecter",
+  "settings.mcpConnectionSuccess": "Connexion réussie ! {{count}} outil(s) disponible(s)",
+  "settings.mcpConnectionFailed": "Échec de la connexion : {{error}}",
+  "settings.mcpNoServers": "Aucun serveur MCP configuré",
+  "settings.testConnectionRequired": "Test de connexion requis avant d'enregistrer",
+  "settings.mcpToolHints": "Outils : {{tools}}",
+
+  // MCP OAuth settings
+  "settings.mcpOAuthEnabled.desc": "Utiliser l'authentification OAuth pour ce serveur",
+  "settings.mcpOAuthAuthenticated": "Authentifié",
+  "settings.mcpOAuthAuthenticating": "Authentification...",
+  "settings.oauthSuccess": "Authentification OAuth réussie pour \"{{name}}\"",
+  "settings.oauthFailed": "Échec de l'authentification OAuth : {{error}}",
+
+  // Input - MCP tool hint
+  "input.mcpToolHint": "({{count}} outils : {{tools}})",
 };

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -750,4 +750,42 @@ export const it: Record<string, string> = {
   "mcpApp.collapse": "Comprimi",
   "mcpApp.error": "Errore MCP App",
   "mcpApp.decodeError": "Impossibile decodificare il contenuto binario",
+
+  // MCP Server Settings
+  "settings.mcpServers": "Server MCP",
+  "settings.mcpServers.desc": "Configura server MCP esterni (Model Context Protocol) per strumenti aggiuntivi",
+  "settings.mcpServersIntro": "I server MCP forniscono strumenti aggiuntivi. Aggiungi server per abilitare i loro strumenti.",
+  "settings.addMcpServer": "Aggiungi server",
+  "settings.mcpServerName": "Nome server",
+  "settings.mcpServerName.placeholder": "Il mio server MCP",
+  "settings.mcpServerUrl": "URL server",
+  "settings.mcpServerUrl.placeholder": "https://example.com/mcp",
+  "settings.mcpServerHeaders": "Intestazioni (JSON)",
+  "settings.mcpServerHeaders.placeholder": "{\"Authorization\": \"Bearer xxx\"}",
+  "settings.mcpServerHeaders.desc": "Intestazioni opzionali per l'autenticazione (formato JSON)",
+  "settings.editMcpServer": "Modifica server MCP",
+  "settings.createMcpServer": "Aggiungi server MCP",
+  "settings.mcpServerCreated": "Server MCP \"{{name}}\" aggiunto",
+  "settings.mcpServerUpdated": "Server MCP \"{{name}}\" aggiornato",
+  "settings.mcpServerDeleted": "Server MCP \"{{name}}\" eliminato",
+  "settings.mcpServerNameRequired": "Il nome del server è obbligatorio",
+  "settings.mcpServerNameDuplicate": "Il nome del server \"{{name}}\" esiste già",
+  "settings.mcpServerUrlRequired": "L'URL del server è obbligatorio",
+  "settings.mcpServerInvalidHeaders": "JSON non valido per le intestazioni",
+  "settings.testMcpConnection": "Connetti",
+  "settings.mcpConnectionSuccess": "Connessione riuscita! {{count}} strumento/i disponibile/i",
+  "settings.mcpConnectionFailed": "Connessione fallita: {{error}}",
+  "settings.mcpNoServers": "Nessun server MCP configurato",
+  "settings.testConnectionRequired": "Test di connessione richiesto prima di salvare",
+  "settings.mcpToolHints": "Strumenti: {{tools}}",
+
+  // MCP OAuth settings
+  "settings.mcpOAuthEnabled.desc": "Usa l'autenticazione OAuth per questo server",
+  "settings.mcpOAuthAuthenticated": "Autenticato",
+  "settings.mcpOAuthAuthenticating": "Autenticazione...",
+  "settings.oauthSuccess": "Autenticazione OAuth riuscita per \"{{name}}\"",
+  "settings.oauthFailed": "Autenticazione OAuth fallita: {{error}}",
+
+  // Input - MCP tool hint
+  "input.mcpToolHint": "({{count}} strumenti: {{tools}})",
 };

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -660,14 +660,22 @@ export const ja: Record<string, string> = {
   "settings.mcpServerUpdated": "MCPサーバー「{{name}}」を更新しました",
   "settings.mcpServerDeleted": "MCPサーバー「{{name}}」を削除しました",
   "settings.mcpServerNameRequired": "サーバー名は必須です",
+  "settings.mcpServerNameDuplicate": "サーバー名「{{name}}」は既に存在します",
   "settings.mcpServerUrlRequired": "サーバーURLは必須です",
   "settings.mcpServerInvalidHeaders": "ヘッダーのJSONが無効です",
-  "settings.testMcpConnection": "接続テスト",
+  "settings.testMcpConnection": "接続",
   "settings.mcpConnectionSuccess": "接続成功！{{count}}個のツールが利用可能です",
   "settings.mcpConnectionFailed": "接続失敗: {{error}}",
   "settings.mcpNoServers": "MCPサーバーが設定されていません",
   "settings.testConnectionRequired": "保存前に接続テストが必要です",
   "settings.mcpToolHints": "ツール: {{tools}}",
+
+  // MCP OAuth settings
+  "settings.mcpOAuthEnabled.desc": "このサーバーでOAuth認証を使用する",
+  "settings.mcpOAuthAuthenticated": "認証済み",
+  "settings.mcpOAuthAuthenticating": "認証中...",
+  "settings.oauthSuccess": "\"{{name}}\"のOAuth認証が成功しました",
+  "settings.oauthFailed": "OAuth認証に失敗しました: {{error}}",
 
   // Input - MCP tool hint
   "input.mcpToolHint": "({{count}}個のツール: {{tools}})",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -750,4 +750,42 @@ export const ko: Record<string, string> = {
   "mcpApp.collapse": "축소",
   "mcpApp.error": "MCP App 오류",
   "mcpApp.decodeError": "바이너리 콘텐츠 디코딩 실패",
+
+  // MCP Server Settings
+  "settings.mcpServers": "MCP 서버",
+  "settings.mcpServers.desc": "추가 도구를 위한 외부 MCP(Model Context Protocol) 서버 구성",
+  "settings.mcpServersIntro": "MCP 서버는 추가 도구를 제공합니다. 서버를 추가하여 도구를 활성화하세요.",
+  "settings.addMcpServer": "서버 추가",
+  "settings.mcpServerName": "서버 이름",
+  "settings.mcpServerName.placeholder": "내 MCP 서버",
+  "settings.mcpServerUrl": "서버 URL",
+  "settings.mcpServerUrl.placeholder": "https://example.com/mcp",
+  "settings.mcpServerHeaders": "헤더 (JSON)",
+  "settings.mcpServerHeaders.placeholder": "{\"Authorization\": \"Bearer xxx\"}",
+  "settings.mcpServerHeaders.desc": "인증을 위한 선택적 헤더 (JSON 형식)",
+  "settings.editMcpServer": "MCP 서버 편집",
+  "settings.createMcpServer": "MCP 서버 추가",
+  "settings.mcpServerCreated": "MCP 서버 \"{{name}}\" 추가됨",
+  "settings.mcpServerUpdated": "MCP 서버 \"{{name}}\" 업데이트됨",
+  "settings.mcpServerDeleted": "MCP 서버 \"{{name}}\" 삭제됨",
+  "settings.mcpServerNameRequired": "서버 이름이 필요합니다",
+  "settings.mcpServerNameDuplicate": "서버 이름 \"{{name}}\"이(가) 이미 존재합니다",
+  "settings.mcpServerUrlRequired": "서버 URL이 필요합니다",
+  "settings.mcpServerInvalidHeaders": "헤더의 JSON이 유효하지 않습니다",
+  "settings.testMcpConnection": "연결",
+  "settings.mcpConnectionSuccess": "연결 성공! {{count}}개의 도구 사용 가능",
+  "settings.mcpConnectionFailed": "연결 실패: {{error}}",
+  "settings.mcpNoServers": "구성된 MCP 서버 없음",
+  "settings.testConnectionRequired": "저장하기 전에 연결 테스트가 필요합니다",
+  "settings.mcpToolHints": "도구: {{tools}}",
+
+  // MCP OAuth settings
+  "settings.mcpOAuthEnabled.desc": "이 서버에 OAuth 인증 사용",
+  "settings.mcpOAuthAuthenticated": "인증됨",
+  "settings.mcpOAuthAuthenticating": "인증 중...",
+  "settings.oauthSuccess": "\"{{name}}\"의 OAuth 인증 성공",
+  "settings.oauthFailed": "OAuth 인증 실패: {{error}}",
+
+  // Input - MCP tool hint
+  "input.mcpToolHint": "({{count}}개 도구: {{tools}})",
 };

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -750,4 +750,42 @@ export const pt: Record<string, string> = {
   "mcpApp.collapse": "Recolher",
   "mcpApp.error": "Erro do MCP App",
   "mcpApp.decodeError": "Falha ao decodificar conteúdo binário",
+
+  // MCP Server Settings
+  "settings.mcpServers": "Servidores MCP",
+  "settings.mcpServers.desc": "Configurar servidores MCP externos (Model Context Protocol) para ferramentas adicionais",
+  "settings.mcpServersIntro": "Os servidores MCP fornecem ferramentas adicionais. Adicione servidores para habilitar suas ferramentas.",
+  "settings.addMcpServer": "Adicionar servidor",
+  "settings.mcpServerName": "Nome do servidor",
+  "settings.mcpServerName.placeholder": "Meu servidor MCP",
+  "settings.mcpServerUrl": "URL do servidor",
+  "settings.mcpServerUrl.placeholder": "https://example.com/mcp",
+  "settings.mcpServerHeaders": "Cabeçalhos (JSON)",
+  "settings.mcpServerHeaders.placeholder": "{\"Authorization\": \"Bearer xxx\"}",
+  "settings.mcpServerHeaders.desc": "Cabeçalhos opcionais para autenticação (formato JSON)",
+  "settings.editMcpServer": "Editar servidor MCP",
+  "settings.createMcpServer": "Adicionar servidor MCP",
+  "settings.mcpServerCreated": "Servidor MCP \"{{name}}\" adicionado",
+  "settings.mcpServerUpdated": "Servidor MCP \"{{name}}\" atualizado",
+  "settings.mcpServerDeleted": "Servidor MCP \"{{name}}\" excluído",
+  "settings.mcpServerNameRequired": "O nome do servidor é obrigatório",
+  "settings.mcpServerNameDuplicate": "O nome do servidor \"{{name}}\" já existe",
+  "settings.mcpServerUrlRequired": "A URL do servidor é obrigatória",
+  "settings.mcpServerInvalidHeaders": "JSON inválido para cabeçalhos",
+  "settings.testMcpConnection": "Conectar",
+  "settings.mcpConnectionSuccess": "Conexão bem-sucedida! {{count}} ferramenta(s) disponível(is)",
+  "settings.mcpConnectionFailed": "Falha na conexão: {{error}}",
+  "settings.mcpNoServers": "Nenhum servidor MCP configurado",
+  "settings.testConnectionRequired": "Teste de conexão necessário antes de salvar",
+  "settings.mcpToolHints": "Ferramentas: {{tools}}",
+
+  // MCP OAuth settings
+  "settings.mcpOAuthEnabled.desc": "Usar autenticação OAuth para este servidor",
+  "settings.mcpOAuthAuthenticated": "Autenticado",
+  "settings.mcpOAuthAuthenticating": "Autenticando...",
+  "settings.oauthSuccess": "Autenticação OAuth bem-sucedida para \"{{name}}\"",
+  "settings.oauthFailed": "Falha na autenticação OAuth: {{error}}",
+
+  // Input - MCP tool hint
+  "input.mcpToolHint": "({{count}} ferramentas: {{tools}})",
 };

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -750,4 +750,42 @@ export const zh: Record<string, string> = {
   "mcpApp.collapse": "收起",
   "mcpApp.error": "MCP App 错误",
   "mcpApp.decodeError": "无法解码二进制内容",
+
+  // MCP Server Settings
+  "settings.mcpServers": "MCP 服务器",
+  "settings.mcpServers.desc": "配置外部 MCP（模型上下文协议）服务器以获取额外工具",
+  "settings.mcpServersIntro": "MCP 服务器提供额外工具。添加服务器以启用其工具。",
+  "settings.addMcpServer": "添加服务器",
+  "settings.mcpServerName": "服务器名称",
+  "settings.mcpServerName.placeholder": "我的 MCP 服务器",
+  "settings.mcpServerUrl": "服务器 URL",
+  "settings.mcpServerUrl.placeholder": "https://example.com/mcp",
+  "settings.mcpServerHeaders": "请求头 (JSON)",
+  "settings.mcpServerHeaders.placeholder": "{\"Authorization\": \"Bearer xxx\"}",
+  "settings.mcpServerHeaders.desc": "用于身份验证的可选请求头（JSON 格式）",
+  "settings.editMcpServer": "编辑 MCP 服务器",
+  "settings.createMcpServer": "添加 MCP 服务器",
+  "settings.mcpServerCreated": "MCP 服务器 \"{{name}}\" 已添加",
+  "settings.mcpServerUpdated": "MCP 服务器 \"{{name}}\" 已更新",
+  "settings.mcpServerDeleted": "MCP 服务器 \"{{name}}\" 已删除",
+  "settings.mcpServerNameRequired": "服务器名称为必填项",
+  "settings.mcpServerNameDuplicate": "服务器名称 \"{{name}}\" 已存在",
+  "settings.mcpServerUrlRequired": "服务器 URL 为必填项",
+  "settings.mcpServerInvalidHeaders": "请求头的 JSON 格式无效",
+  "settings.testMcpConnection": "连接",
+  "settings.mcpConnectionSuccess": "连接成功！{{count}} 个工具可用",
+  "settings.mcpConnectionFailed": "连接失败：{{error}}",
+  "settings.mcpNoServers": "未配置 MCP 服务器",
+  "settings.testConnectionRequired": "保存前需要测试连接",
+  "settings.mcpToolHints": "工具：{{tools}}",
+
+  // MCP OAuth settings
+  "settings.mcpOAuthEnabled.desc": "为此服务器使用 OAuth 身份验证",
+  "settings.mcpOAuthAuthenticated": "已认证",
+  "settings.mcpOAuthAuthenticating": "认证中...",
+  "settings.oauthSuccess": "\"{{name}}\" 的 OAuth 身份验证成功",
+  "settings.oauthFailed": "OAuth 身份验证失败：{{error}}",
+
+  // Input - MCP tool hint
+  "input.mcpToolHint": "({{count}} 个工具：{{tools}})",
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import type { Content } from "@google/genai";
+import type { OAuthConfig, OAuthTokens } from "../core/oauth";
 
 // MCP (Model Context Protocol) server configuration
 export interface McpServerConfig {
@@ -7,6 +8,8 @@ export interface McpServerConfig {
   headers?: Record<string, string>;  // Optional headers for authentication
   enabled: boolean;       // Whether this server is enabled for chat
   toolHints?: string[];   // Tool names from test connection (for display hints)
+  oauth?: OAuthConfig;    // OAuth configuration (if server requires OAuth)
+  oauthTokens?: OAuthTokens;  // OAuth tokens (access token, refresh token, etc.)
 }
 
 // MCP tool information (from server)


### PR DESCRIPTION
- Create oauth.ts module with PKCE-based OAuth 2.0 flow
- Register Obsidian protocol handler (obsidian://gemini-helper-oauth) for callback
- Add OAuth configuration fields to McpServerConfig type
- Update McpServerModal with OAuth settings UI (client ID, auth URL, token URL, scopes)
- Integrate OAuth authentication flow in MCP server test connection
- Support automatic token refresh when expired
- Add i18n translations for OAuth settings (en, ja)
