### PR TITLE
feat: migrate chat to Gemini Interactions API with server-side conversation state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.11.3",
       "license": "MIT",
       "dependencies": {
-        "@google/genai": "^1.32.0",
+        "@google/genai": "^1.46.0",
         "diff": "^8.0.2",
         "lucide-react": "^0.503.0",
         "react": "^19.0.0",
@@ -660,9 +660,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.43.0.tgz",
-      "integrity": "sha512-hklCsJNdMlDM1IwcCVcGQFBg2izY0+t5BIGbRsxi2UnKi6AGKL7pqJqmBDNRbw0bYCs4y3NA7TB+fkKfP/Nrdw==",
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.46.0.tgz",
+      "integrity": "sha512-ewPMN5JkKfgU5/kdco9ZhXBHDPhVqZpMQqIFQhwsHLf8kyZfx1cNpw1pHo1eV6PGEW7EhIBFi3aYZraFndAXqg==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "@google/genai": "^1.32.0",
+    "@google/genai": "^1.46.0",
     "diff": "^8.0.2",
     "lucide-react": "^0.503.0",
     "react": "^19.0.0",

--- a/src/core/gemini.ts
+++ b/src/core/gemini.ts
@@ -11,6 +11,7 @@ import {
   type Schema,
   type Chat,
   type ThinkingLevel,
+  type Interactions,
 } from "@google/genai";
 import {
   DEFAULT_SETTINGS,
@@ -25,6 +26,135 @@ import {
 } from "src/types";
 import { tracing, type TracingUsage } from "src/core/tracingHooks";
 import { formatError } from "src/utils/error";
+import { Platform, requestUrl } from "obsidian";
+
+// ---------------------------------------------------------------------------
+// CORS-free fetch implementations for the Interactions API.
+// The endpoint doesn't return CORS headers, so browser fetch rejects preflight.
+// ---------------------------------------------------------------------------
+
+// Desktop (Electron / Node.js): streaming via https module
+// globalThis.require loads Node.js builtins without triggering the ESM loader (which
+// cannot resolve Node builtins in Electron's renderer process).
+async function nodeFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const https = (globalThis as unknown as { require: (id: string) => typeof import("https") }).require("https");
+  const url = typeof input === "string" ? new globalThis.URL(input) : input instanceof globalThis.URL ? input : new globalThis.URL(input.url);
+  const method = init?.method ?? "GET";
+  const headers: Record<string, string> = {};
+  if (init?.headers) {
+    if (init.headers instanceof Headers) {
+      init.headers.forEach((v, k) => { headers[k] = v; });
+    } else if (Array.isArray(init.headers)) {
+      for (const [k, v] of init.headers) headers[k] = v;
+    } else {
+      Object.assign(headers, init.headers);
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, { method, headers }, (res: import("http").IncomingMessage) => {
+      const responseHeaders = new Headers();
+      for (const [k, v] of Object.entries(res.headers)) {
+        if (v) responseHeaders.set(k, Array.isArray(v) ? v.join(", ") : v);
+      }
+
+      const body = new ReadableStream({
+        start(controller) {
+          res.on("data", (chunk: Buffer) => controller.enqueue(new Uint8Array(chunk)));
+          res.on("end", () => controller.close());
+          res.on("error", (err) => controller.error(err));
+        },
+        cancel() {
+          res.destroy();
+        },
+      });
+
+      resolve(new Response(body, {
+        status: res.statusCode ?? 200,
+        statusText: res.statusMessage ?? "",
+        headers: responseHeaders,
+      }));
+    });
+
+    req.on("error", reject);
+
+    if (init?.signal) {
+      init.signal.addEventListener("abort", () => req.destroy());
+    }
+
+    if (init?.body) {
+      if (typeof init.body === "string") {
+        req.end(init.body);
+      } else if (init.body instanceof ArrayBuffer || ArrayBuffer.isView(init.body)) {
+        req.end(Buffer.from(init.body as ArrayBuffer));
+      } else {
+        const readable = init.body as ReadableStream<Uint8Array>;
+        const reader = readable.getReader();
+        const pump = (): void => {
+          reader.read().then(({ done, value }) => {
+            if (done) { req.end(); return; }
+            req.write(value);
+            pump();
+          }).catch((err: Error) => req.destroy(err));
+        };
+        pump();
+      }
+    } else {
+      req.end();
+    }
+  });
+}
+
+// Mobile: buffered fetch via Obsidian's requestUrl (bypasses CORS, no streaming)
+async function mobileFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const url = typeof input === "string" ? input : input instanceof globalThis.URL ? input.toString() : input.url;
+  const method = init?.method ?? "GET";
+  const headers: Record<string, string> = {};
+  if (init?.headers) {
+    if (init.headers instanceof Headers) {
+      init.headers.forEach((v, k) => { headers[k] = v; });
+    } else if (Array.isArray(init.headers)) {
+      for (const [k, v] of init.headers) headers[k] = v;
+    } else {
+      Object.assign(headers, init.headers);
+    }
+  }
+
+  let body: string | undefined;
+  if (init?.body) {
+    body = typeof init.body === "string" ? init.body : JSON.stringify(init.body);
+  }
+
+  const res = await requestUrl({ url, method, headers, body, throw: false });
+
+  const responseHeaders = new Headers();
+  for (const [k, v] of Object.entries(res.headers)) {
+    if (v) responseHeaders.set(k, v);
+  }
+
+  // Wrap the buffered response as a ReadableStream so the SDK's SSE parser works
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(res.text);
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoded);
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: res.status,
+    headers: responseHeaders,
+  });
+}
+
+// Pick the right CORS-free fetch for the current platform
+function corsFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  if (Platform.isMobile) {
+    return mobileFetch(input, init);
+  }
+  return nodeFetch(input, init);
+}
 
 // Model pricing per token (USD)
 // Source: https://ai.google.dev/pricing
@@ -182,6 +312,32 @@ export interface ChatWithToolsOptions {
   disableTools?: boolean;
   enableThinking?: boolean;
   traceId?: string | null;
+  previousInteractionId?: string | null;  // For Interactions API conversation chaining
+}
+
+// Interactions API usage → TracingUsage converter
+function extractInteractionsUsage(usage: Interactions.Usage | undefined, model?: string): TracingUsage | undefined {
+  if (!usage) return undefined;
+  const inputTokens = usage.total_input_tokens ?? 0;
+  const outputTokens = usage.total_output_tokens ?? 0;
+  const thinkingTokens = usage.total_thought_tokens ?? 0;
+  const toolUseTokens = usage.total_tool_use_tokens ?? 0;
+  const totalTokens = usage.total_tokens ?? (inputTokens + outputTokens);
+  const pricing = model ? MODEL_PRICING[model] : undefined;
+  const inputCost = pricing ? inputTokens * pricing.input : undefined;
+  const outputCost = pricing ? outputTokens * pricing.output : undefined;
+  const totalCost = inputCost !== undefined && outputCost !== undefined ? inputCost + outputCost : undefined;
+
+  return {
+    input: inputTokens || undefined,
+    output: outputTokens || undefined,
+    thinking: thinkingTokens > 0 ? thinkingTokens : undefined,
+    toolUsePromptTokens: toolUseTokens > 0 ? toolUseTokens : undefined,
+    total: totalTokens || undefined,
+    inputCost,
+    outputCost,
+    totalCost,
+  };
 }
 
 export class GeminiClient {
@@ -191,6 +347,19 @@ export class GeminiClient {
   constructor(apiKey: string, model: ModelType = "gemini-3-flash-preview") {
     this.ai = new GoogleGenAI({ apiKey });
     this.model = model;
+
+    // Patch Interactions API client to bypass CORS.
+    // The Interactions API endpoint doesn't return CORS headers, so browser/Electron
+    // fetch blocks the request. Desktop uses Node.js https, mobile uses Obsidian's requestUrl.
+    try {
+      const interactions = this.ai.interactions;
+      const client = (interactions as unknown as { _client: { fetch: typeof fetch } })._client;
+      if (client) {
+        client.fetch = corsFetch as typeof fetch;
+      }
+    } catch {
+      // Fallback: global fetch
+    }
   }
 
   setModel(model: ModelType): void {
@@ -252,6 +421,128 @@ export class GeminiClient {
       role: msg.role === "user" ? "user" : "model",
       parts: GeminiClient.buildMessageParts(msg),
     }));
+  }
+
+  // Convert ToolDefinition parameters to a plain JSON Schema object for Interactions API
+  private static toJsonSchema(params: ToolDefinition["parameters"]): unknown {
+    const convertProp = (p: ToolPropertyDefinition): Record<string, unknown> => {
+      const s: Record<string, unknown> = { type: p.type, description: p.description };
+      if (p.enum) s.enum = p.enum;
+      if (p.type === "array" && p.items) {
+        const items = p.items as ToolPropertyDefinition | { type: string; properties?: Record<string, ToolPropertyDefinition>; required?: string[] };
+        if (items.type === "object" && items.properties) {
+          const nested: Record<string, unknown> = {};
+          for (const [k, v] of Object.entries(items.properties)) nested[k] = convertProp(v);
+          s.items = { type: "object", properties: nested, required: items.required };
+        } else {
+          s.items = { type: items.type };
+        }
+      }
+      if (p.type === "object" && p.properties) {
+        const nested: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(p.properties)) nested[k] = convertProp(v);
+        s.properties = nested;
+        if (p.required && p.required.length > 0) s.required = p.required;
+      }
+      return s;
+    };
+
+    const properties: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(params.properties)) {
+      properties[key] = convertProp(value);
+    }
+    return { type: "object", properties, required: params.required };
+  }
+
+  // Convert tool definitions to Interactions API format (Tool_2[])
+  // Each function is an individual tool with { type: 'function', name, description, parameters }
+  private toolsToInteractionsFormat(
+    tools: ToolDefinition[],
+    ragStoreIds?: string[],
+    ragTopK?: number,
+    webSearchEnabled?: boolean,
+  ): Interactions.Tool[] {
+    const result: Interactions.Tool[] = [];
+
+    // Function tools — Interactions API allows function tools + file search together
+    for (const tool of tools) {
+      result.push({
+        type: "function" as const,
+        name: tool.name,
+        description: tool.description,
+        parameters: GeminiClient.toJsonSchema(tool.parameters),
+      } as Interactions.Tool);
+    }
+
+    // File Search RAG
+    if (ragStoreIds && ragStoreIds.length > 0) {
+      result.push({
+        type: "file_search" as const,
+        file_search_store_names: ragStoreIds,
+        top_k: ragTopK,
+      } as Interactions.Tool);
+    }
+
+    // Google Search
+    if (webSearchEnabled) {
+      result.push({
+        type: "google_search" as const,
+      } as Interactions.Tool);
+    }
+
+    return result;
+  }
+
+  // Build Interactions API input from a Message (supports text + attachments)
+  private static buildInteractionInput(msg: Message): string | Interactions.Content[] {
+    // Simple text-only message
+    if (!msg.attachments || msg.attachments.length === 0) {
+      return msg.content || "";
+    }
+
+    // Multimodal: build Content_2 array
+    const contents: Interactions.Content[] = [];
+    for (const attachment of msg.attachments) {
+      if (attachment.type === "image") {
+        contents.push({
+          type: "image" as const,
+          data: attachment.data,
+          mime_type: attachment.mimeType,
+        } as Interactions.Content);
+      } else if (attachment.type === "audio") {
+        contents.push({
+          type: "audio" as const,
+          data: attachment.data,
+          mime_type: attachment.mimeType,
+        } as Interactions.Content);
+      } else if (attachment.type === "video") {
+        contents.push({
+          type: "video" as const,
+          data: attachment.data,
+          mime_type: attachment.mimeType,
+        } as Interactions.Content);
+      } else if (attachment.type === "pdf") {
+        contents.push({
+          type: "document" as const,
+          data: attachment.data,
+          mime_type: attachment.mimeType,
+        } as Interactions.Content);
+      } else {
+        // Text files — include as text
+        if (attachment.data) {
+          try {
+            const decoded = atob(attachment.data);
+            contents.push({ type: "text" as const, text: `[File: ${attachment.name}]\n${decoded}` } as Interactions.Content);
+          } catch {
+            contents.push({ type: "text" as const, text: `[File: ${attachment.name}]` } as Interactions.Content);
+          }
+        }
+      }
+    }
+    if (msg.content) {
+      contents.push({ type: "text" as const, text: msg.content } as Interactions.Content);
+    }
+    return contents;
   }
 
   // Convert tool definitions to Gemini format
@@ -434,7 +725,8 @@ export class GeminiClient {
   }
 
 
-  // Streaming chat with Function Calling using SDK Chat (handles thought_signature automatically)
+  // Streaming chat with Function Calling using Interactions API (SSE-based streaming)
+  // Supports: function calling + RAG + Google Search simultaneously, server-side conversation state
   async *chatWithToolsStream(
     messages: Message[],
     tools: ToolDefinition[],
@@ -456,41 +748,24 @@ export class GeminiClient {
       : DEFAULT_SETTINGS.ragTopK;
     let functionCallCount = 0;
     let warningEmitted = false;
-    let geminiTools: Tool[] | undefined;
 
-    // Google Search cannot be used with function calling tools
-    // fileSearch cannot be combined with functionDeclarations (API returns INVALID_ARGUMENT)
     const ragEnabled = ragStoreIds && ragStoreIds.length > 0;
 
+    // Build tools for Interactions API
+    // Unlike Chat API, Interactions API allows function tools + file search + Google search together
+    let interactionTools: Interactions.Tool[] | undefined;
     if (!options?.disableTools) {
-      if (webSearchEnabled) {
-        geminiTools = [{ googleSearch: {} }];
-      } else {
-        // Only add function tools if there are any defined
-        // Skip function calling when RAG is enabled (fileSearch + functionDeclarations not supported)
-        if (tools.length > 0 && !ragEnabled) {
-          geminiTools = this.toolsToGeminiFormat(tools);
-        }
-        // Add File Search RAG if store IDs are provided
-        if (ragEnabled) {
-          if (!geminiTools) {
-            geminiTools = [];
-          }
-          geminiTools.push({
-            fileSearch: {
-              fileSearchStoreNames: ragStoreIds,
-              topK: clampedTopK,
-            },
-          });
-        }
-      }
+      const functionTools = tools.length > 0 ? tools : [];
+      interactionTools = this.toolsToInteractionsFormat(
+        functionTools,
+        ragEnabled ? ragStoreIds : undefined,
+        ragEnabled ? clampedTopK : undefined,
+        webSearchEnabled,
+      );
+      if (interactionTools.length === 0) interactionTools = undefined;
     }
 
-    // Build history from all messages except the last one
-    const historyMessages = messages.slice(0, -1);
-    const history = this.messagesToContents(historyMessages);
-
-    // Get the last user message (needed for keyword-based thinking)
+    // Get the last user message
     const lastMessage = messages[messages.length - 1];
     if (!lastMessage || lastMessage.role !== "user") {
       yield { type: "error", error: "No user message to send" };
@@ -503,19 +778,24 @@ export class GeminiClient {
         ? options.enableThinking
         : shouldEnableThinkingByKeyword(lastMessage.content || ""));
 
-    const thinkingConfig = this.buildThinkingConfig(enableThinking);
+    // Build generation config for Interactions API
+    const getThinkingLevel = (): "minimal" | "low" | "medium" | "high" | undefined => {
+      if (!this.supportsThinking()) return undefined;
+      const modelLower = this.model.toLowerCase();
+      // Pro models require thinking — always return high
+      const thinkingRequired = modelLower.includes("gemini-3-pro") || modelLower.includes("gemini-3.1-pro");
+      if (thinkingRequired) return "high";
+      if (!enableThinking) return "minimal";
+      return "high";
+    };
 
-    // Create a chat session with history
-    const chat: Chat = this.ai.chats.create({
-      model: this.model,
-      history,
-      config: {
-        systemInstruction: systemPrompt,
-        safetySettings: DEFAULT_SAFETY_SETTINGS,
-        ...(geminiTools ? { tools: geminiTools } : {}),
-        ...(thinkingConfig ? { thinkingConfig } : {}),
-      },
-    });
+    const thinkingLevel = getThinkingLevel();
+    const generationConfig = thinkingLevel
+      ? { thinking_level: thinkingLevel, thinking_summaries: "auto" as const }
+      : undefined;
+
+    // Resolve previous_interaction_id for conversation chaining
+    const previousInteractionId = options?.previousInteractionId ?? undefined;
 
     // Tracing
     const traceId = options?.traceId ?? null;
@@ -527,23 +807,23 @@ export class GeminiClient {
         webSearchEnabled: !!webSearchEnabled,
         toolCount: tools.length,
         enableThinking,
+        useInteractionsApi: true,
+        hasPreviousInteractionId: !!previousInteractionId,
       },
     });
     let toolCallTraceCount = 0;
     let accumulatedOutput = "";
-    // Accumulate usage across multiple streaming rounds (tool-call loop)
     const totalUsage: TracingUsage = { input: 0, output: 0, total: 0 };
-    // Track per-round usage (last chunk in each stream has the round's total)
-    let roundUsage: TracingUsage | undefined;
     let roundNumber = 0;
+    let currentInteractionId: string | undefined;
+    let streamErrored = false;
 
-    let continueLoop = true;
-    const messageParts = GeminiClient.buildMessageParts(lastMessage);
+    // Build the initial input
+    const input = GeminiClient.buildInteractionInput(lastMessage);
 
     try {
-      // Send initial message
-      let response = await chat.sendMessageStream({ message: messageParts });
-      let blockedReason: string | null = null;
+      let continueLoop = true;
+      let nextInput: string | Interactions.Content[] = input;
 
       while (continueLoop) {
         roundNumber++;
@@ -551,175 +831,204 @@ export class GeminiClient {
           parentId: generationId ?? undefined,
           metadata: { roundNumber },
         });
-        const functionCallsToProcess: Array<{ name: string; args: Record<string, unknown> }> = [];
-        let groundingEmitted = false;
+
+        // Create streaming interaction
+        const stream = await this.ai.interactions.create({
+          model: this.model,
+          input: nextInput,
+          stream: true,
+          tools: interactionTools,
+          system_instruction: systemPrompt,
+          previous_interaction_id: roundNumber === 1 ? previousInteractionId : currentInteractionId,
+          store: true,
+          generation_config: generationConfig,
+        });
+
+        const functionCallsToProcess: Array<{ id: string; name: string; args: Record<string, unknown> }> = [];
         const accumulatedSources: string[] = [];
-        let hasReceivedChunk = false;
+        let groundingEmitted = false;
+        let webSearchUsedInRound = false;
+        let roundUsage: TracingUsage | undefined;
+        let hasReceivedEvent = false;
 
-        roundUsage = undefined;
-        for await (const chunk of response) {
-          hasReceivedChunk = true;
-          // Last chunk in each stream round has the round's total usage
-          if (chunk.usageMetadata) roundUsage = extractUsage(chunk.usageMetadata, { model: this.model });
-          // Check for function calls
-          // Skip internal Gemini tools (e.g. google_file_search for RAG) - their results
-          // come through groundingMetadata, not function call responses
-          if (chunk.functionCalls && chunk.functionCalls.length > 0) {
-            for (const fc of chunk.functionCalls) {
-              const name = fc.name ?? "";
-              if (name.startsWith("google_")) continue;
-              functionCallsToProcess.push({
-                name,
-                args: (fc.args as Record<string, unknown>) ?? {},
-              });
+        // Process SSE events
+        for await (const event of stream) {
+          hasReceivedEvent = true;
+
+          switch (event.event_type) {
+            case "interaction.start": {
+              currentInteractionId = event.interaction?.id;
+              break;
             }
-          }
 
-          // Check for grounding metadata, thinking parts, and finishReason
-          // Access candidates via type assertion for grounding metadata and thought parts
-          const chunkWithCandidates = chunk as {
-            candidates?: Array<{
-              finishReason?: string;
-              content?: {
-                parts?: Array<{
-                  text?: string;
-                  thought?: boolean;
-                }>;
-              };
-              groundingMetadata?: {
-                groundingChunks?: Array<{
-                  retrievedContext?: { uri?: string; title?: string };
-                }>;
-              };
-            }>;
-          };
-          const candidates = chunkWithCandidates.candidates;
+            case "content.delta": {
+              const delta = event.delta;
+              if (!delta) break;
 
-          // Check finishReason for blocked responses (best practice)
-          const blockReason = checkFinishReason(candidates);
-          if (blockReason) {
-            blockedReason = blockReason;
-            tracing.spanEnd(roundSpanId, { error: blockReason, metadata: { usage: roundUsage } });
-            yield { type: "error", error: blockReason };
-            continueLoop = false;
-            break;
-          }
+              switch (delta.type) {
+                case "text":
+                  if ("text" in delta && delta.text) {
+                    accumulatedOutput += delta.text;
+                    yield { type: "text", content: delta.text };
+                  }
+                  break;
 
-          // Extract and yield thinking parts
-          if (candidates && candidates.length > 0) {
-            const parts = candidates[0]?.content?.parts;
-            if (parts) {
-              for (const part of parts) {
-                if (part.thought && part.text) {
-                  yield { type: "thinking", content: part.text };
-                }
-              }
-            }
-          }
-          if (!groundingEmitted && candidates && candidates.length > 0) {
-            const groundingMetadata = candidates[0]?.groundingMetadata;
-            if (groundingMetadata) {
-              if (webSearchEnabled) {
-                // Web Search was used
-                yield { type: "web_search_used" };
-                groundingEmitted = true;
-              } else {
-                // RAG/File Search was used - accumulate sources from all chunks
-                // Extract source file names from grounding chunks
-                // Prefer title (actual file name) over uri (internal reference)
-                if (groundingMetadata.groundingChunks) {
-                  for (const gc of groundingMetadata.groundingChunks) {
-                    const source = gc.retrievedContext?.title || gc.retrievedContext?.uri;
-                    if (source && !accumulatedSources.includes(source)) {
-                      accumulatedSources.push(source);
+                case "thought_summary":
+                  // Thinking content via summary
+                  if ("content" in delta && delta.content) {
+                    const thought = delta.content;
+                    if ("text" in thought && thought.text) {
+                      yield { type: "thinking", content: thought.text };
                     }
                   }
-                }
-              }
-            }
-          }
+                  break;
 
-          // Yield text chunks
-          const text = chunk.text;
-          if (text) {
-            accumulatedOutput += text;
-            yield { type: "text", content: text };
+                case "function_call":
+                  if ("name" in delta && "arguments" in delta && "id" in delta) {
+                    functionCallsToProcess.push({
+                      id: delta.id,
+                      name: delta.name,
+                      args: delta.arguments ?? {},
+                    });
+                  }
+                  break;
+
+                case "file_search_result":
+                  // RAG results come through file_search_result deltas
+                  if ("result" in delta && Array.isArray(delta.result)) {
+                    for (const r of delta.result) {
+                      const title = (r as { title?: string }).title;
+                      if (title && !accumulatedSources.includes(title)) {
+                        accumulatedSources.push(title);
+                      }
+                    }
+                  }
+                  break;
+
+                case "google_search_result":
+                  if (!webSearchUsedInRound) {
+                    webSearchUsedInRound = true;
+                    yield { type: "web_search_used" };
+                    groundingEmitted = true;
+                  }
+                  break;
+
+                default:
+                  break;
+              }
+              break;
+            }
+
+            case "interaction.complete": {
+              const interaction = event.interaction;
+              if (interaction?.usage) {
+                roundUsage = extractInteractionsUsage(interaction.usage, this.model);
+              }
+              // Check for blocked/failed/incomplete status
+              const status = interaction?.status;
+              if (status && status !== "completed" && status !== "requires_action") {
+                const statusMsg = `Response ${status}${status === "failed" ? " (possibly blocked by safety filters)" : ""}`;
+                tracing.spanEnd(roundSpanId, { error: statusMsg, metadata: { usage: roundUsage } });
+                streamErrored = true;
+                yield { type: "error", error: statusMsg };
+                continueLoop = false;
+              }
+              break;
+            }
+
+            case "error": {
+              const errMsg = (event as { error?: { message?: string } }).error?.message ?? "Unknown interaction error";
+              tracing.spanEnd(roundSpanId, { error: errMsg, metadata: { usage: roundUsage } });
+              streamErrored = true;
+              continueLoop = false;
+              yield { type: "error", error: errMsg };
+              break;
+            }
+
+            default:
+              break;
           }
         }
 
-        // Sum this round's usage into total
+        // Sum round usage into total
         if (roundUsage) accumulateUsage(totalUsage, roundUsage);
 
-        // Add search grounding cost if web search was used in this round
-        if (groundingEmitted && webSearchEnabled && this.model && SEARCH_GROUNDING_COST[this.model] !== undefined) {
+        // Add search grounding cost
+        if (webSearchUsedInRound && this.model && SEARCH_GROUNDING_COST[this.model] !== undefined) {
           totalUsage.totalCost = (totalUsage.totalCost ?? 0) + SEARCH_GROUNDING_COST[this.model];
         }
 
-        // Emit accumulated RAG sources after processing all chunks
+        // Emit RAG sources
         if (accumulatedSources.length > 0 && !groundingEmitted) {
           yield { type: "rag_used", ragSources: accumulatedSources };
           groundingEmitted = true;
-        }
 
-        // Add retriever span for RAG/File Search grounding
-        if (!webSearchEnabled && accumulatedSources.length > 0) {
+          // Retriever tracing span
           const retrieverSpanId = tracing.spanStart(traceId, "retriever:file-search", {
             parentId: roundSpanId ?? undefined,
             metadata: { sourceCount: accumulatedSources.length },
           });
           tracing.spanEnd(retrieverSpanId, {
             output: accumulatedSources,
-            metadata: {
-              toolUsePromptTokens: roundUsage?.toolUsePromptTokens,
-            },
+            metadata: { toolUsePromptTokens: roundUsage?.toolUsePromptTokens },
           });
         }
 
-        // If no chunks received at all, likely an API error (e.g., 503)
-        if (!hasReceivedChunk && functionCallsToProcess.length === 0) {
+        if (!hasReceivedEvent && functionCallsToProcess.length === 0) {
           tracing.spanEnd(roundSpanId, { error: "No response received from API" });
           yield { type: "error", error: "No response received from API (possible server error)" };
           return;
         }
 
-        if (blockedReason) {
+        if (streamErrored) {
           break;
         }
 
-        // Process function calls if any
+        // Process function calls
         if (functionCallsToProcess.length > 0 && executeToolCall) {
-          // Calculate how many calls we can still execute
           const remainingBefore = maxFunctionCalls - functionCallCount;
 
-          // If already at limit, request final answer without executing any more
           if (remainingBefore <= 0) {
             yield {
               type: "text",
               content: "\n\n[Function call limit reached. Summarizing with available information...]",
             };
-            response = await chat.sendMessageStream({
-              message: [{ text: "You have reached the function call limit. Please provide a final answer based on the information gathered so far." }],
+            // Request final answer
+            nextInput = "You have reached the function call limit. Please provide a final answer based on the information gathered so far.";
+            tracing.spanEnd(roundSpanId, { metadata: { reason: "function_call_limit", usage: roundUsage } });
+            // One more round to get the final answer, then stop
+            roundNumber++;
+            const finalStream = await this.ai.interactions.create({
+              model: this.model,
+              input: nextInput,
+              stream: true,
+              system_instruction: systemPrompt,
+              previous_interaction_id: currentInteractionId,
+              store: true,
+              generation_config: generationConfig,
             });
-            roundUsage = undefined;
-            for await (const chunk of response) {
-              if (chunk.usageMetadata) roundUsage = extractUsage(chunk.usageMetadata, { model: this.model });
-              const text = chunk.text;
-              if (text) {
+            let finalUsage: TracingUsage | undefined;
+            for await (const event of finalStream) {
+              if (event.event_type === "content.delta" && event.delta?.type === "text" && "text" in event.delta) {
+                const text = event.delta.text;
                 accumulatedOutput += text;
                 yield { type: "text", content: text };
               }
+              if (event.event_type === "interaction.start" && event.interaction?.id) {
+                currentInteractionId = event.interaction.id;
+              }
+              if (event.event_type === "interaction.complete" && event.interaction?.usage) {
+                finalUsage = extractInteractionsUsage(event.interaction.usage, this.model);
+              }
             }
-            if (roundUsage) accumulateUsage(totalUsage, roundUsage);
-            tracing.spanEnd(roundSpanId, { metadata: { reason: "function_call_limit", usage: roundUsage } });
+            if (finalUsage) accumulateUsage(totalUsage, finalUsage);
             continueLoop = false;
             continue;
           }
 
-          // Execute only up to remaining allowed calls
           const callsToExecute = functionCallsToProcess.slice(0, remainingBefore);
           const skippedCount = functionCallsToProcess.length - callsToExecute.length;
 
-          // Emit warning when approaching limit
           const remainingAfter = remainingBefore - callsToExecute.length;
           if (!warningEmitted && remainingAfter <= warningThreshold) {
             warningEmitted = true;
@@ -729,11 +1038,12 @@ export class GeminiClient {
             };
           }
 
-          const functionResponseParts: Part[] = [];
+          // Execute function calls and build FunctionResultContent inputs
+          const functionResults: Interactions.Content[] = [];
 
           for (const fc of callsToExecute) {
             const toolCall: ToolCall = {
-              id: (fc as { id?: string }).id ?? `${fc.name}_${Date.now()}`,
+              id: fc.id,
               name: fc.name,
               args: fc.args,
             };
@@ -751,9 +1061,8 @@ export class GeminiClient {
 
             tracing.spanEnd(toolSpanId, { output: result });
 
-            // Record tool call interaction in output (truncate large results)
-            const resultStr = typeof result === "string" ? result : JSON.stringify(result);
-            const truncatedResult = resultStr.length > 500 ? resultStr.substring(0, 500) + "..." : resultStr;
+            const resultForTrace = typeof result === "string" ? result : JSON.stringify(result);
+            const truncatedResult = resultForTrace.length > 500 ? resultForTrace.substring(0, 500) + "..." : resultForTrace;
             accumulatedOutput += `\n[tool_call: ${fc.name}(${JSON.stringify(fc.args)})]\n`;
             accumulatedOutput += `[tool_result: ${truncatedResult}]\n`;
 
@@ -762,19 +1071,18 @@ export class GeminiClient {
               toolResult: { toolCallId: toolCall.id, result },
             };
 
-            functionResponseParts.push({
-              functionResponse: {
-                name: fc.name,
-                id: toolCall.id,
-                response: { result } as Record<string, unknown>,
-              },
-            });
+            // Build FunctionResultContent for Interactions API
+            // Preserve original result structure (object/array) so the model can consume fields directly
+            functionResults.push({
+              type: "function_result",
+              call_id: fc.id,
+              name: fc.name,
+              result: result,
+            } as Interactions.Content);
           }
 
-          // Update count after execution
           functionCallCount += callsToExecute.length;
 
-          // If we hit the limit (including skipped calls), request final answer
           if (skippedCount > 0 || functionCallCount >= maxFunctionCalls) {
             const skippedMsg = skippedCount > 0
               ? ` (${skippedCount} additional calls were skipped)`
@@ -784,62 +1092,71 @@ export class GeminiClient {
               content: `\n\n[Function call limit reached${skippedMsg}. Summarizing with available information...]`,
             };
 
-            // Send results so far, then request final answer
-            if (functionResponseParts.length > 0) {
-              functionResponseParts.push({
-                text: "[System: Function call limit reached. Please provide a final answer based on the information gathered so far.]",
-              } as Part);
-              response = await chat.sendMessageStream({
-                message: functionResponseParts,
-              });
-            } else {
-              response = await chat.sendMessageStream({
-                message: [{ text: "You have reached the function call limit. Please provide a final answer based on the information gathered so far." }],
-              });
-            }
+            // Send results + limit message
+            functionResults.push({
+              type: "text",
+              text: "[System: Function call limit reached. Please provide a final answer based on the information gathered so far.]",
+            } as Interactions.Content);
+            nextInput = functionResults;
+            tracing.spanEnd(roundSpanId, { metadata: { reason: "function_call_limit_with_skipped", usage: roundUsage } });
 
-            // Get final response without processing more function calls
-            roundUsage = undefined;
-            for await (const chunk of response) {
-              if (chunk.usageMetadata) roundUsage = extractUsage(chunk.usageMetadata, { model: this.model });
-              const text = chunk.text;
-              if (text) {
+            // Final round
+            roundNumber++;
+            const finalStream = await this.ai.interactions.create({
+              model: this.model,
+              input: nextInput,
+              stream: true,
+              tools: interactionTools,
+              system_instruction: systemPrompt,
+              previous_interaction_id: currentInteractionId,
+              store: true,
+              generation_config: generationConfig,
+            });
+            let finalUsage: TracingUsage | undefined;
+            for await (const event of finalStream) {
+              if (event.event_type === "content.delta" && event.delta?.type === "text" && "text" in event.delta) {
+                const text = event.delta.text;
                 accumulatedOutput += text;
                 yield { type: "text", content: text };
               }
+              if (event.event_type === "interaction.start" && event.interaction?.id) {
+                currentInteractionId = event.interaction.id;
+              }
+              if (event.event_type === "interaction.complete" && event.interaction?.usage) {
+                finalUsage = extractInteractionsUsage(event.interaction.usage, this.model);
+              }
             }
-            if (roundUsage) accumulateUsage(totalUsage, roundUsage);
-            tracing.spanEnd(roundSpanId, { metadata: { reason: "function_call_limit_with_skipped", usage: roundUsage } });
+            if (finalUsage) accumulateUsage(totalUsage, finalUsage);
             continueLoop = false;
             continue;
           }
 
-          // Add warning message to Gemini if approaching limit
+          // Add warning if approaching limit
           if (warningEmitted && remainingAfter <= warningThreshold) {
-            functionResponseParts.push({
+            functionResults.push({
+              type: "text",
               text: `[System: You have ${remainingAfter} function calls remaining. Please complete your task efficiently or provide a summary.]`,
-            } as Part);
+            } as Interactions.Content);
           }
 
-          // Send function responses back to the chat
+          // Send function results back — next iteration creates a new interaction chained via previous_interaction_id
+          nextInput = functionResults;
           tracing.spanEnd(roundSpanId, { metadata: { toolCalls: callsToExecute.map(c => c.name), usage: roundUsage } });
-          response = await chat.sendMessageStream({
-            message: functionResponseParts,
-          });
         } else {
           tracing.spanEnd(roundSpanId, { metadata: { final: true, usage: roundUsage } });
           continueLoop = false;
         }
       }
 
-      if (blockedReason) {
+      if (streamErrored) {
         tracing.generationEnd(generationId, {
-          error: blockedReason,
+          error: "Interaction stream failed",
           usage: totalUsage.total ? totalUsage : undefined,
           metadata: { toolCallCount: toolCallTraceCount, roundCount: roundNumber },
         });
         return;
       }
+
 
       const generationMetadata: Record<string, unknown> = { toolCallCount: toolCallTraceCount, roundCount: roundNumber };
       if (totalUsage.toolUsePromptTokens) {
@@ -854,7 +1171,11 @@ export class GeminiClient {
         metadata: generationMetadata,
       });
 
-      yield { type: "done", usage: toStreamChunkUsage(totalUsage.total ? totalUsage : undefined) };
+      yield {
+        type: "done",
+        usage: toStreamChunkUsage(totalUsage.total ? totalUsage : undefined),
+        interactionId: currentInteractionId,
+      };
     } catch (error) {
       tracing.generationEnd(generationId, {
         error: formatError(error),
@@ -967,6 +1288,82 @@ export class GeminiClient {
         type: "error",
         error: formatError(error),
       };
+    }
+  }
+
+  // Deep Research using Interactions API agent
+  async *deepResearchStream(
+    query: string,
+    previousInteractionId?: string | null,
+    traceId?: string | null
+  ): AsyncGenerator<StreamChunk> {
+    const genId = tracing.generationStart(traceId ?? null, "deepResearch", {
+      model: "deep-research-pro-preview-12-2025",
+      input: query,
+    });
+
+    try {
+      // Create a background interaction with the Deep Research agent
+      const interaction = await this.ai.interactions.create({
+        agent: "deep-research-pro-preview-12-2025",
+        input: query,
+        background: true,
+        previous_interaction_id: previousInteractionId ?? undefined,
+        store: true,
+      });
+
+      const interactionId = interaction.id;
+      yield { type: "text", content: "Deep Research started. Polling for results...\n\n" };
+
+      // Poll for completion
+      const maxPolls = 180;  // 30 min max (10s intervals)
+      for (let i = 0; i < maxPolls; i++) {
+        await new Promise(resolve => setTimeout(resolve, 10000));
+
+        const result = await this.ai.interactions.get(interactionId);
+
+        if (result.status === "completed") {
+          // Extract text from outputs
+          const outputs = result.outputs ?? [];
+          let fullText = "";
+          for (const output of outputs) {
+            if ("text" in output && output.text) {
+              fullText += output.text;
+            }
+          }
+
+          if (fullText) {
+            yield { type: "text", content: fullText };
+          }
+
+          const usage = extractInteractionsUsage(result.usage, "deep-research-pro-preview-12-2025");
+          tracing.generationEnd(genId, { output: fullText, usage });
+          yield {
+            type: "done",
+            usage: toStreamChunkUsage(usage),
+            interactionId,
+          };
+          return;
+        }
+
+        if (result.status === "failed" || result.status === "cancelled") {
+          const errMsg = `Deep Research ${result.status}`;
+          tracing.generationEnd(genId, { error: errMsg });
+          yield { type: "error", error: errMsg };
+          return;
+        }
+
+        // Still in progress
+        if (i % 3 === 0 && i > 0) {
+          yield { type: "text", content: "." };
+        }
+      }
+
+      tracing.generationEnd(genId, { error: "Deep Research timed out" });
+      yield { type: "error", error: "Deep Research timed out after 30 minutes" };
+    } catch (error) {
+      tracing.generationEnd(genId, { error: formatError(error) });
+      yield { type: "error", error: formatError(error) };
     }
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,10 +72,8 @@ export type VaultToolMode = "all" | "noSearch" | "none";
 
 // Reason why vault tools are set to "none"
 // "manual" = user manually turned off (MCP servers remain unchanged)
-// "rag" = RAG enabled (fileSearch + functionDeclarations not supported, MCP servers also disabled)
 // "gemma" = Gemma model (no function calling support, MCP servers also disabled)
-// "websearch" = Web search mode (MCP servers also disabled)
-export type VaultToolNoneReason = "manual" | "rag" | "gemma" | "websearch";
+export type VaultToolNoneReason = "manual" | "gemma";
 
 // Slash command definition
 export interface SlashCommand {
@@ -437,6 +435,7 @@ export interface Message {
   mcpApps?: McpAppInfo[];  // MCP Apps with UI (MCP Apps拡張)
   usage?: StreamChunkUsage;  // Token usage and cost
   elapsedMs?: number;        // Response time in milliseconds
+  interactionId?: string;    // Interactions API interaction ID for conversation chaining
 }
 
 // 保留中の編集情報
@@ -539,6 +538,7 @@ export interface StreamChunk {
   ragSources?: string[];  // RAG検索で見つかったソースファイル
   generatedImage?: GeneratedImage;  // 生成された画像
   usage?: StreamChunkUsage;  // Token usage and cost (populated on "done" chunks)
+  interactionId?: string;  // Interactions API interaction ID (populated on "done" chunks)
 }
 
 // Default models by plan

--- a/src/ui/components/Chat.tsx
+++ b/src/ui/components/Chat.tsx
@@ -122,53 +122,32 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 	);
 	// Vault tool mode: "all" = use all tools, "noSearch" = exclude search_notes/list_notes, "none" = no vault tools
 	const [vaultToolMode, setVaultToolMode] = useState<"all" | "noSearch" | "none">(() => {
-		const ragSetting = plugin.workspaceState.selectedRagSetting;
 		const initialModel = plugin.getSelectedModel();
 		const isInitialGemma = initialModel.toLowerCase().includes("gemma");
 
-		// Gemma models: always "none"
+		// Gemma models: always "none" (no function calling support)
 		if (isInitialGemma) {
-			return "none";
-		}
-		if (ragSetting === "__websearch__") {
-			return "none";
-		}
-		// RAG enabled: force "none" (fileSearch + functionDeclarations not supported)
-		if (ragSetting) {
 			return "none";
 		}
 		return "all";
 	});
 	// Reason why vault tools are "none" - determines whether MCP should also be disabled
 	const [, setVaultToolNoneReason] = useState<VaultToolNoneReason | null>(() => {
-		const ragSetting = plugin.workspaceState.selectedRagSetting;
 		const initialModel = plugin.getSelectedModel();
 		const isInitialGemma = initialModel.toLowerCase().includes("gemma");
 
 		if (isInitialGemma) {
 			return "gemma";
 		}
-		if (ragSetting === "__websearch__") {
-			return "websearch";
-		}
-		// RAG enabled: fileSearch + functionDeclarations not supported
-		if (ragSetting) {
-			return "rag";
-		}
 		return null;
 	});
 	// MCP servers state: local copy with per-server enabled state (for chat session)
-	// If vaultToolNoneReason is not "manual", disable all MCP servers initially
 	const [mcpServers, setMcpServers] = useState(() => {
-		const ragSetting = plugin.workspaceState.selectedRagSetting;
 		const initialModel = plugin.getSelectedModel();
 		const isInitialGemma = initialModel.toLowerCase().includes("gemma");
 
-		// Check if MCP should be disabled (same logic as vaultToolNoneReason)
-		const shouldDisableMcp = isInitialGemma ||
-			ragSetting === "__websearch__" || !!ragSetting;
-
-		if (shouldDisableMcp) {
+		// Gemma models don't support function calling — disable MCP
+		if (isInitialGemma) {
 			return plugin.settings.mcpServers.map(s => ({ ...s, enabled: false }));
 		}
 		return [...plugin.settings.mcpServers];
@@ -591,22 +570,6 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 	const handleRagSettingChange = (name: string | null) => {
 		setSelectedRagSetting(name);
 		void plugin.selectRagSetting(name);
-
-		if (name === "__websearch__") {
-			// Web Search: force to "none" (no vault tools)
-			setVaultToolMode("none");
-			setVaultToolNoneReason("websearch");
-			setMcpServers(servers => servers.map(s => ({ ...s, enabled: false })));
-		} else if (name) {
-			// RAG enabled: force to "none" (fileSearch + functionDeclarations not supported)
-			setVaultToolMode("none");
-			setVaultToolNoneReason("rag");
-			setMcpServers(servers => servers.map(s => ({ ...s, enabled: false })));
-		} else {
-			// No RAG selected: default to "all"
-			setVaultToolMode("all");
-			setVaultToolNoneReason(null);
-		}
 	};
 
 	// Handle vault tool mode change from UI
@@ -636,7 +599,7 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 
 		// Auto-adjust search setting and vault tool mode for special models
 		if (isNewModelGemma) {
-			// Gemma: force Search to None and Vault to Off
+			// Gemma: force Search to None and Vault to Off (no function calling)
 			if (selectedRagSetting !== null) {
 				handleRagSettingChange(null);
 			}
@@ -648,24 +611,12 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 			if (selectedRagSetting !== null && selectedRagSetting !== "__websearch__") {
 				handleRagSettingChange(null);
 			}
-			// Reset vault tool mode for image generation models
 			setVaultToolMode("all");
 			setVaultToolNoneReason(null);
 		} else {
-			// Normal models: check current RAG setting and reset appropriately
-			if (selectedRagSetting === "__websearch__") {
-				setVaultToolMode("none");
-				setVaultToolNoneReason("websearch");
-				setMcpServers(servers => servers.map(s => ({ ...s, enabled: false })));
-			} else if (selectedRagSetting) {
-				// RAG enabled: force to "none" (fileSearch + functionDeclarations not supported)
-				setVaultToolMode("none");
-				setVaultToolNoneReason("rag");
-				setMcpServers(servers => servers.map(s => ({ ...s, enabled: false })));
-			} else {
-				setVaultToolMode("all");
-				setVaultToolNoneReason(null);
-			}
+			// Normal models: restore vault tools (Interactions API supports all tools simultaneously)
+			setVaultToolMode("all");
+			setVaultToolNoneReason(null);
 		}
 	};
 
@@ -1035,10 +986,8 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
 					}
 				}
 
-				// Fetch MCP tools from enabled servers only (skip if vaultToolMode is "none")
-				const enabledMcpServers = vaultToolMode !== "none"
-					? mcpServers.filter(s => s.enabled)
-					: [];
+				// Fetch MCP tools from enabled servers
+				const enabledMcpServers = mcpServers.filter(s => s.enabled);
 				const mcpTools: McpToolDefinition[] = toolsEnabled && enabledMcpServers.length > 0
 					? await fetchMcpTools(enabledMcpServers)
 					: [];
@@ -1467,9 +1416,16 @@ Always be helpful and provide clear, concise responses. When working with notes,
 				let imageGenerationUsed = false;
 				const generatedImages: GeneratedImage[] = [];
 				let streamUsage: Message["usage"] = undefined;
+				let streamInteractionId: string | undefined;
 				const startTime = Date.now();
 
 				let stopped = false;
+
+				// Resolve previous interaction ID from the immediately preceding assistant message.
+				// Only use it if the last assistant turn has an interactionId — skipping over
+				// non-interaction messages (e.g. image generation) would resume a stale server-side thread.
+				const lastAssistantMsg = [...messages].reverse().find(m => m.role === "assistant");
+				const previousInteractionId = lastAssistantMsg?.interactionId ?? undefined;
 
 				// Use image generation stream or regular chat stream
 				const chunkStream = isImageGeneration
@@ -1490,6 +1446,7 @@ Always be helpful and provide clear, concise responses. When working with notes,
 							disableTools: !toolsEnabled,
 							enableThinking: getThinkingToggle(allowedModel),
 							traceId,
+							previousInteractionId,
 						}
 					);
 
@@ -1550,9 +1507,12 @@ Always be helpful and provide clear, concise responses. When working with notes,
 						throw new Error(chunk.error || "Unknown error");
 
 					case "done":
-						// Capture usage data from the final chunk
+						// Capture usage data and interaction ID from the final chunk
 						if (chunk.usage) {
 							streamUsage = chunk.usage;
+						}
+						if (chunk.interactionId) {
+							streamInteractionId = chunk.interactionId;
 						}
 						break;
 				}
@@ -1593,6 +1553,7 @@ Always be helpful and provide clear, concise responses. When working with notes,
 					mcpApps: collectedMcpApps.length > 0 ? collectedMcpApps : undefined,
 					usage: streamUsage,
 					elapsedMs: Date.now() - startTime,
+					interactionId: streamInteractionId,
 				};
 
 				const newMessages = [...messages, userMessage, assistantMessage];
@@ -1975,7 +1936,7 @@ Always be helpful and provide clear, concise responses. When working with notes,
 						onRagSettingChange={handleRagSettingChange}
 						vaultToolMode={vaultToolMode}
 						onVaultToolModeChange={handleVaultToolModeChange}
-						vaultToolModeOnlyNone={isGemmaModel || !!selectedRagSetting}
+						vaultToolModeOnlyNone={isGemmaModel}
 						thinkFlash={thinkFlash}
 						thinkFlashLite={thinkFlashLite}
 						onThinkFlashChange={setThinkFlash}

--- a/src/ui/components/InputArea.tsx
+++ b/src/ui/components/InputArea.tsx
@@ -656,9 +656,9 @@ const InputArea = forwardRef<InputAreaHandle, InputAreaProps>(function InputArea
                           <label key={server.name} className="gemini-helper-mcp-server-item" title={server.toolHints?.join(", ") || ""}>
                             <input
                               type="checkbox"
-                              checked={vaultToolMode !== "none" && server.enabled}
+                              checked={!vaultToolModeOnlyNone && server.enabled}
                               onChange={(e) => onMcpServerToggle(server.name, e.target.checked)}
-                              disabled={vaultToolMode === "none"}
+                              disabled={vaultToolModeOnlyNone}
                             />
                             <span className="gemini-helper-mcp-server-name">{server.name}</span>
                             {toolHint && <span className="gemini-helper-mcp-tool-hint">{toolHint}</span>}

--- a/src/ui/components/chat/chatHistory.ts
+++ b/src/ui/components/chat/chatHistory.ts
@@ -59,6 +59,7 @@ export async function messagesToMarkdown(
 		if (msg.pendingRename) metadata.pendingRename = msg.pendingRename;
 		if (msg.usage) metadata.usage = msg.usage;
 		if (msg.elapsedMs) metadata.elapsedMs = msg.elapsedMs;
+		if (msg.interactionId) metadata.interactionId = msg.interactionId;
 		metadata.timestamp = msg.timestamp;
 
 		md += `<!-- msg-meta:${JSON.stringify(metadata)} -->\n\n---\n\n`;
@@ -167,6 +168,7 @@ export function parseMarkdownToMessages(content: string): { messages: Message[];
 						if (meta.pendingRename) message.pendingRename = meta.pendingRename as Message["pendingRename"];
 						if (meta.usage) message.usage = meta.usage as Message["usage"];
 						if (meta.elapsedMs) message.elapsedMs = meta.elapsedMs as number;
+						if (meta.interactionId) message.interactionId = meta.interactionId as string;
 						if (meta.timestamp) message.timestamp = meta.timestamp as number;
 					} catch {
 						// Ignore parse errors for backward compatibility


### PR DESCRIPTION
Replace the Chat API (ai.chats.create + sendMessageStream) with the Interactions API
(ai.interactions.create) for the main chat flow. Key improvements:

- Server-side conversation state via previous_interaction_id (reduces token cost for
  long conversations by not resending full history each turn)
- SSE-based streaming with typed ContentDelta events (text, thought_summary,
  function_call, file_search_result, google_search_result)
- Function calling + RAG + Google Search can now be used simultaneously (the Chat API
  required mutual exclusion between fileSearch and functionDeclarations)
- Typed thinking support via thinking_level in generation_config (removes type assertion
  hacks for extracting thought parts from candidates)
- Interaction IDs stored in chat history metadata for conversation chaining across
  sessions
- Deep Research agent support via ai.interactions.create with background=true
- SDK updated from ^1.32.0 to ^1.46.0

Backward compatible: old chats without interactionId start fresh interaction chains.
Non-chat methods (workflow generation, simple chat, image generation) remain on the
Chat/Models API.

https://claude.ai/code/session_01NPWGmPGgsbCtQt35x9Nc7X