### PR TITLE
Rename `gemini-3-flash-preview` to `gemini-3.5-flash` and bump version to 1.13.9

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,5 +7,5 @@
 	"authorUrl": "https://github.com/takeshy",
 	"fundingUrl": "https://buymeacoffee.com/takeshy",
 	"isDesktopOnly": false,
-	"version": "1.13.8"
+	"version": "1.13.9"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-gemini-helper",
-  "version": "1.13.8",
+  "version": "1.13.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-gemini-helper",
-      "version": "1.13.8",
+      "version": "1.13.9",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.46.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-gemini-helper",
-  "version": "1.13.8",
+  "version": "1.13.9",
   "description": "AI-powered assistant using Google Gemini with File Search RAG capabilities",
   "main": "main.js",
   "scripts": {

--- a/src/core/gemini.ts
+++ b/src/core/gemini.ts
@@ -163,7 +163,7 @@ const MODEL_PRICING: Record<string, { input: number; output: number }> = {
   "gemini-2.5-flash":       { input: 0.30 / 1e6, output: 2.50 / 1e6 },
   "gemini-2.5-flash-lite":  { input: 0.10 / 1e6, output: 0.40 / 1e6 },
   "gemini-2.5-pro":         { input: 1.25 / 1e6, output: 10.00 / 1e6 },
-  "gemini-3-flash-preview": { input: 0.50 / 1e6, output: 3.00 / 1e6 },
+  "gemini-3.5-flash": { input: 0.50 / 1e6, output: 3.00 / 1e6 },
   "gemini-3.1-flash-lite": { input: 0.25 / 1e6, output: 1.50 / 1e6 },
   "gemini-3.1-pro-preview": { input: 2.00 / 1e6, output: 12.00 / 1e6 },
   "gemini-3.1-pro-preview-customtools": { input: 2.00 / 1e6, output: 12.00 / 1e6 },
@@ -175,7 +175,7 @@ const MODEL_PRICING: Record<string, { input: number; output: number }> = {
 // Gemini 3 models: $14/1K queries, Gemini 2.x: $35/1K prompts
 // Approximated as per-prompt since exact query count is not exposed by the API
 const SEARCH_GROUNDING_COST: Record<string, number> = {
-  "gemini-3-flash-preview": 14 / 1000,
+  "gemini-3.5-flash": 14 / 1000,
   "gemini-3.1-pro-preview": 14 / 1000,
   "gemini-3.1-pro-preview-customtools": 14 / 1000,
   "gemini-3-pro-image-preview": 14 / 1000,
@@ -426,7 +426,7 @@ export class GeminiClient {
   private ai: GoogleGenAI;
   private model: ModelType;
 
-  constructor(apiKey: string, model: ModelType = "gemini-3-flash-preview") {
+  constructor(apiKey: string, model: ModelType = "gemini-3.5-flash") {
     this.ai = new GoogleGenAI({ apiKey });
     this.model = model;
 

--- a/src/core/workspaceStateManager.ts
+++ b/src/core/workspaceStateManager.ts
@@ -102,6 +102,9 @@ export class WorkspaceStateManager {
     if ((this.workspaceState.selectedModel as string) === "gemini-3.1-flash-lite-preview") {
       this.workspaceState.selectedModel = "gemini-3.1-flash-lite";
     }
+    if ((this.workspaceState.selectedModel as string) === "gemini-3-flash-preview") {
+      this.workspaceState.selectedModel = "gemini-3.5-flash";
+    }
     if ((this.workspaceState.selectedModel as string) === "gemini-2.5-flash-image") {
       this.workspaceState.selectedModel = "gemini-3.1-flash-image-preview";
     }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -46,6 +46,7 @@ import { registerWorkflowCodeBlockProcessor } from "src/ui/workflowCodeBlock";
 function normalizeDeprecatedModelName(model: unknown): ModelType | null | undefined {
   if (model === null || model === undefined) return model;
   if (model === "gemini-3.1-flash-lite-preview") return "gemini-3.1-flash-lite";
+  if (model === "gemini-3-flash-preview") return "gemini-3.5-flash";
   return model as ModelType;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -264,7 +264,7 @@ export type ApiPlan = "paid" | "free";
 export type ModelType =
   | "gemini-2.5-flash"
   | "gemini-2.5-pro"
-  | "gemini-3-flash-preview"
+  | "gemini-3.5-flash"
   | "gemini-3.1-pro-preview"
   | "gemini-3.1-pro-preview-customtools"
   | "gemini-3.1-flash-lite"
@@ -293,8 +293,8 @@ export const PAID_MODELS: ModelInfo[] = [
     description: "Optimized for agentic workflows with custom tools and bash",
   },
   {
-    name: "gemini-3-flash-preview",
-    displayName: "Gemini 3 Flash Preview",
+    name: "gemini-3.5-flash",
+    displayName: "Gemini 3.5 Flash",
     description: "Fast model with 1M context, best cost-performance",
   },
   {
@@ -348,9 +348,9 @@ export const FREE_MODELS: ModelInfo[] = [
     description: "Free tier lightweight model",
   },
   {
-    name: "gemini-3-flash-preview",
-    displayName: "Gemini 3 Flash Preview",
-    description: "Free tier preview model",
+    name: "gemini-3.5-flash",
+    displayName: "Gemini 3.5 Flash",
+    description: "Free tier fast model",
   },
   {
     name: "gemini-3.1-flash-lite",


### PR DESCRIPTION
### Motivation
- Align model identifiers with upstream naming by replacing the deprecated `gemini-3-flash-preview` with the new `gemini-3.5-flash` model across the codebase.
- Ensure persisted workspace state and legacy settings migrate correctly to the new model name to avoid breakage for existing users.
- Update package and manifest versions to publish the change.

### Description
- Replaced occurrences of `gemini-3-flash-preview` with `gemini-3.5-flash` in model lists, display names, and default selections in `src/types/index.ts`, `src/core/gemini.ts`, and related files.
- Updated pricing and search grounding maps keys to use `gemini-3.5-flash` in `src/core/gemini.ts` to keep cost calculations consistent with the renamed model.
- Changed the default constructor model in `GeminiClient` to `gemini-3.5-flash` in `src/core/gemini.ts` and added a migration path for old model names in `src/core/workspaceStateManager.ts` and `normalizeDeprecatedModelName` in `src/plugin.ts` to translate legacy values at load time.
- Bumped project versions in `manifest.json`, `package.json`, and `package-lock.json` from `1.13.8` to `1.13.9`.

### Testing
- Ran the automated test suite with `npm test` (Vitest) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d38293a8c832585976555e83ac99b)