### PR TITLE
docs: add BundleDex badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gemini Helper for Obsidian
 
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-takeshy%2Fobsidian--gemini--helper-blue.svg?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTQgMTloMTZhMiAyIDAgMCAwIDItMlY3YTIgMiAwIDAgMC0yLTJINWEyIDIgMCAwIDAtMiAydjEyYTIgMiAwIDAgMSAyLTJ6Ii8+PHBhdGggZD0iTTkgMTV2LTQiLz48cGF0aCBkPSJNMTIgMTV2LTIiLz48cGF0aCBkPSJNMTUgMTV2LTQiLz48L3N2Zz4=)](https://deepwiki.com/takeshy/obsidian-gemini-helper)
+[![BundleDex](https://bundledex.net/badge/obsidian-gemini-helper.svg)](https://bundledex.net/bundles/obsidian-gemini-helper/)
 
 **Free and open-source** AI assistant for Obsidian with **Chat**, **Workflow Automation**, and **RAG** powered by Google Gemini.
 


### PR DESCRIPTION
Adds the BundleDex badge to show this repository is indexed in the BundleDex OKF directory. [BundleDex](https://bundledex.net) is the go-to directory for Open Knowledge Format bundles used by AI agents.

The BundleDex listing at https://bundledex.net/bundles/obsidian-gemini-helper/ has been updated to accurately reflect that this is an Obsidian plugin (not an OKF bundle directly). The listing now correctly marks it as non-OKF-conformant since the plugin uses OKF bundles rather than being one itself.

If you'd like any further adjustments to the listing or badge, please let me know!