### PR TITLE
docs: add BundleDex badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gemini Helper for Obsidian
 
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-takeshy%2Fobsidian--gemini--helper-blue.svg?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTQgMTloMTZhMiAyIDAgMCAwIDItMlY3YTIgMiAwIDAgMC0yLTJINWEyIDIgMCAwIDAtMiAydjEyYTIgMiAwIDAgMSAyLTJ6Ii8+PHBhdGggZD0iTTkgMTV2LTQiLz48cGF0aCBkPSJNMTIgMTV2LTIiLz48cGF0aCBkPSJNMTUgMTV2LTQiLz48L3N2Zz4=)](https://deepwiki.com/takeshy/obsidian-gemini-helper)
+[![BundleDex](https://bundledex.net/badge/obsidian-gemini-helper.svg)](https://bundledex.net/bundles/obsidian-gemini-helper/)
 
 **Free and open-source** AI assistant for Obsidian with **Chat**, **Workflow Automation**, and **RAG** powered by Google Gemini.
 

--- a/README.md
+++ b/README.md
@@ -751,6 +751,8 @@ Requires: `pip install cryptography`
 
 See [Google AI Terms of Service](https://ai.google.dev/terms) for data retention policies.
 
+[![OKF BundleDex](https://bundledex.net/static-badge.svg)](https://bundledex.net)
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gemini Helper for Obsidian
 
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-takeshy%2Fobsidian--gemini--helper-blue.svg?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTQgMTloMTZhMiAyIDAgMCAwIDItMlY3YTIgMiAwIDAgMC0yLTJINWEyIDIgMCAwIDAtMiAydjEyYTIgMiAwIDAgMSAyLTJ6Ii8+PHBhdGggZD0iTTkgMTV2LTQiLz48cGF0aCBkPSJNMTIgMTV2LTIiLz48cGF0aCBkPSJNMTUgMTV2LTQiLz48L3N2Zz4=)](https://deepwiki.com/takeshy/obsidian-gemini-helper)
-[![BundleDex](https://bundledex.net/badge/obsidian-gemini-helper.svg)](https://bundledex.net/bundles/obsidian-gemini-helper/)
+[![BundleDex](https://bundledex.net/static-badge.svg)](https://bundledex.net)
 
 **Free and open-source** AI assistant for Obsidian with **Chat**, **Workflow Automation**, and **RAG** powered by Google Gemini.
 


### PR DESCRIPTION
This PR adds a badge linking to [BundleDex](https://bundledex.net), the curated directory of OKF knowledge bundles (420+ bundles indexed).

Your plugin has first-class OKF Knowledge Sources support — it's one of the most practical OKF integrations in the Obsidian ecosystem. The badge helps users discover your work through the directory.

*AI-assisted PR — happy to close if this doesn't fit the project!*